### PR TITLE
Update Lambdas runtime to Nodejs 14

### DIFF
--- a/source/lib/limit-monitor-spoke-stack.ts
+++ b/source/lib/limit-monitor-spoke-stack.ts
@@ -202,7 +202,7 @@ export class LimitMonitorSpokeStack extends cdk.Stack {
                 enabled: true,
             },
             lambdaFunctionProps: {
-                runtime: lambda.Runtime.NODEJS_12_X,
+                runtime: lambda.Runtime.NODEJS_14_X,
                 code: lambda.Code.fromBucket(solutionsLambdaCodeBucket, props.solutionName + '/' + props.solutionVersion + '/limtr-refresh-service.zip'),
                 description: 'Serverless Limit Monitor - Lambda function to summarize service limits',
                 timeout: cdk.Duration.seconds(300),
@@ -297,7 +297,7 @@ export class LimitMonitorSpokeStack extends cdk.Stack {
         cfn_ref_limtrHelperRole.overrideLogicalId('LimtrHelperRole')
 
         const limtrHelperFunction = new lambda.Function(this, 'LimtrHelperFunction', {
-                    runtime: lambda.Runtime.NODEJS_12_X,
+                    runtime: lambda.Runtime.NODEJS_14_X,
                     description: 'This function generates UUID, establishes cross account trust on CloudWatch Event Bus and sends anonymous metric',
                     handler: 'index.handler',
                     code: lambda.Code.fromBucket(solutionsLambdaCodeBucket, props.solutionName + '/' + props.solutionVersion + '/limtr-helper-service.zip'),

--- a/source/lib/limit-monitor-stack.ts
+++ b/source/lib/limit-monitor-stack.ts
@@ -156,7 +156,7 @@ export class LimitMonitorStack extends cdk.Stack {
           SLACK_CHANNEL: cdk.Fn.sub('SlackChannel'),
           LOG_LEVEL: 'INFO'
         },
-        runtime: lambda.Runtime.NODEJS_12_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         code: lambda.Code.fromBucket(solutionSourceCodeBucket, slackNotifierLambdaSourceCodeS3Key),
         handler: 'index.handler',
         role: slackNotifierLambdaRole,
@@ -421,7 +421,7 @@ export class LimitMonitorStack extends cdk.Stack {
           SOLUTION: props.solutionId, //'SO0005'
           LOG_LEVEL: 'INFO'  //change to WARN, ERROR or DEBUG as needed
         },
-        runtime: lambda.Runtime.NODEJS_12_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         code: lambda.Code.fromBucket(solutionSourceCodeBucket, limitSummarizerLambdaSourceCodeS3Key),
         handler: 'index.handler',
         role: limitSummarizerLambdaRole,
@@ -510,7 +510,7 @@ export class LimitMonitorStack extends cdk.Stack {
           AWS_SERVICES: cdk.Fn.findInMap('EventsMap', 'Checks', 'Services'),
           LOG_LEVEL: 'INFO'  //change to WARN, ERROR or DEBUG as needed
         },
-        runtime: lambda.Runtime.NODEJS_12_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         code: lambda.Code.fromBucket(solutionSourceCodeBucket, taRefresherLambdaSourceCodeS3Key),
         handler: 'index.handler',
         role: taRefresherLambdaRole,
@@ -606,7 +606,7 @@ export class LimitMonitorStack extends cdk.Stack {
       environment: {
         LOG_LEVEL: 'INFO'
       },
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromBucket(solutionSourceCodeBucket, LimtrHelperLambdaSourceCodeS3Key),
       handler: 'index.handler',
       role: limtrHelperLambdaRole,

--- a/source/lib/service-quotas-checks-stack.ts
+++ b/source/lib/service-quotas-checks-stack.ts
@@ -57,7 +57,7 @@ export class ServiceQuotasChecksStack extends cdk.Stack {
     const limitMonitorEventsRuleToLambdaProps: EventsRuleToLambdaProps = {
       lambdaFunctionProps: {
         description: 'This function checks for vCPU limits and sends notification on WARN and ERROR status',
-        runtime: lambda.Runtime.NODEJS_12_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         code: lambda.Code.fromBucket(solutionSourceCodeBucket, limitMonitorLambdaSourceCodeS3Key),
         handler: 'index.handler',
         //role: limitMonitorLambdaRole,

--- a/source/test/__snapshots__/limit-monitor-spoke-stack.test.ts.snap
+++ b/source/test/__snapshots__/limit-monitor-spoke-stack.test.ts.snap
@@ -146,7 +146,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -338,7 +338,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 300,
         "TracingConfig": Object {
           "Mode": "Active",

--- a/source/test/__snapshots__/limit-monitor-stack.test.ts.snap
+++ b/source/test/__snapshots__/limit-monitor-stack.test.ts.snap
@@ -500,7 +500,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 300,
         "TracingConfig": Object {
           "Mode": "Active",
@@ -771,7 +771,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -1132,7 +1132,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 300,
         "TracingConfig": Object {
           "Mode": "Active",
@@ -1506,7 +1506,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 300,
         "TracingConfig": Object {
           "Mode": "Active",

--- a/source/test/__snapshots__/service-quotas-checks-stack.test.ts.snap
+++ b/source/test/__snapshots__/service-quotas-checks-stack.test.ts.snap
@@ -285,7 +285,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 300,
         "TracingConfig": Object {
           "Mode": "Active",


### PR DESCRIPTION
AWS announced Nodejs 12 end of support for Lambdas.

*Issue #, if available:*

*Description of changes:*

Updating `lambda.Runtime.NODEJS_12_X` to `lambda.Runtime.NODEJS_14_X`

The changes on the snapshots dir were added after I ran the tests locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
